### PR TITLE
Fix watch option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 npm-debug.log
 node_modules
 file.*
+.idea

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -55,13 +55,15 @@ function MochaMulti(runner) {
         num -= 1;
         onClose();
       });
-    })
+    });
     onClose();
 
     function onClose() {
       if (num === 0) {
-        debug('Exiting.');
-        exit()
+        if (! program.watch) {
+          debug('Exiting.');
+          exit();
+        }
       }
     }
   })


### PR DESCRIPTION
mocha-multi exists after running tests even when using `-w` or `--watch` option. This fixes the issue.
