### PR TITLE
Remove restrictions for mocha 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "debug": "~0.7.4"
   },
   "peerDependencies": {
-    "mocha": ">=1.15.1 <2.0.0"
+    "mocha": ">=1.15.1"
   }
 }


### PR DESCRIPTION
I removed the restrictions for mocha < 2.0.0
It seem to be working fine when using in combination with both spec and xunit reports.
I did not bump the package version. Leaving that to you if you accept the pull request.
