### PR TITLE
add support for reporter options when using mocha-multi programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ multi='dot=- xunit=file.xml doc=docs.html' mocha -R mocha-multi
 
 The special value of `-` (hyphen) for destination uses normal stdout/stderr.
 
+Using mocha-multi programmatically
+----------------------------------
+
+Specify the desired reporters (and their options) by passing reporterOptions to the Mocha contructor
+
+for example: this is the equivalent of multi='spec=- Progress=/tmp/mocha-multi.Progress.out', with the addition of passing the verbose:true option to the Progress reporter
+```sh
+var reporterOptions={
+	Progress:{ 
+		stdout:"/tmp/mocha-multi.Progress.out",
+		options: {
+			verbose: true
+		}
+	},
+	spec: {
+		stdout:"-"
+	}
+};
+
+var mocha = new Mocha({
+    ui: 'bdd',
+    reporter: "mocha-multi",
+    reporterOptions:reporterOptions
+});
+mocha.addFile("test/dummy-spec.js");
+mocha.run(function onRun(failures){
+    console.log(failures);
+});
+```
+The options will be passed as the second argument to the reporter constructor
+
 How it works
 ------------
 

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -37,7 +37,7 @@ process.exit = function(code) {
 
 function MochaMulti(runner, options) {
   var setup;
-  if( options && Object.keys(options.reporterOptions).length > 0 ) {
+  if( options && options.reporterOptions && Object.keys(options.reporterOptions).length > 0 ) {
     debug("options %j %j", options, options.reporterOptions);
     setup=[];
     var reporters=Object.keys(options.reporterOptions);

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -36,17 +36,20 @@ process.exit = function(code) {
 }
 
 function MochaMulti(runner, options) {
-  var setup=[];
-  if( options && options.reporterOptions ) {
-    debug("options %j", options.reporterOptions);
+  var setup;
+  if( Object.keys(options.reporterOptions).length > 0 ) {
+    debug("options %j %j", options, options.reporterOptions);
+    setup=[];
     var reporters=Object.keys(options.reporterOptions);
     reporters.forEach(function(reporter) {
-      debug("%j %j", options.reporterOptions, reporter);
+      debug("adding reporter %j %j", options.reporterOptions, reporter);
       setup.push([ reporter, options.reporterOptions[reporter].stdout, options.reporterOptions[reporter].options ]);
     });
+  } else {
+    setup=parseSetup();
   }
   debug("setup %j", setup);
-  var streams = initReportersAndStreams(runner, setup || parseSetup());
+  var streams = initReportersAndStreams(runner, setup);
   // Remove nulls
   streams = streams.filter(identity);
 

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -37,7 +37,7 @@ process.exit = function(code) {
 
 function MochaMulti(runner, options) {
   var setup;
-  if( Object.keys(options.reporterOptions).length > 0 ) {
+  if( options && Object.keys(options.reporterOptions).length > 0 ) {
     debug("options %j %j", options, options.reporterOptions);
     setup=[];
     var reporters=Object.keys(options.reporterOptions);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "homepage": "https://github.com/glenjamin/mocha-multi",
   "devDependencies": {
-    "mocha": ">=1.15.1 <3.0.0"
+    "mocha": "^2.2.4",
+    "q": "^1.2.0",
+    "should": "^5.2.0"
   },
   "dependencies": {
     "debug": "~0.7.4"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/glenjamin/mocha-multi",
   "devDependencies": {
+    "async": "^0.9.0",
     "mocha": "^2.2.4",
     "q": "^1.2.0",
     "should": "^5.2.0"

--- a/verify.js
+++ b/verify.js
@@ -10,6 +10,8 @@ var reporters=[
     "json-stream", "markdown", "nyan"
 ], deferreds=[], now=new Date();
 
+should(process.env['multi']).not.be.ok;
+
 reporters.forEach(function(r) {
     var reporter=r, reporterOptions={}, deferred;
     reporterOptions[reporter]={ 
@@ -30,7 +32,8 @@ reporters.forEach(function(r) {
 Q.all(deferreds).then(function() {
     process.on('exit', function onExit() {
         reporters.forEach(function(reporter) {
-            fs.statSync("/tmp/mocha-multi."+reporter+"."+now).should.be.ok;            
+            fs.statSync("/tmp/mocha-multi."+reporter+"."+now).should.be.ok;
+            fs.unlinkSync("/tmp/mocha-multi."+reporter+"."+now);
         });
     });
 });

--- a/verify.js
+++ b/verify.js
@@ -1,0 +1,37 @@
+var Mocha = require('mocha'), 
+    should=require('should'),
+    fs=require('fs'),
+    Q=require('q'),
+    debug = require('debug')('mocha:multi');
+
+var reporters=[
+    "dot", "doc", "spec", "json", "progress",
+    "list", "tap", "landing", "xunit", "min",
+    "json-stream", "markdown", "nyan"
+], deferreds=[];
+
+reporters.forEach(function(r) {
+    var reporter=r, reporterOptions={}, deferred;
+    reporterOptions[reporter]={ 
+        stdout:"/tmp/spec."+reporter+".out"
+    };
+    deferred=Q.defer();
+    deferreds.push( deferred.promise );
+    var mocha = new Mocha({
+        ui: 'bdd',
+        reporter: "mocha-multi",
+        reporterOptions:reporterOptions
+    });
+    mocha.addFile("test/dummy-spec.js");
+    mocha.run(function onRun(failures){
+        deferred.resolve({});
+    });
+});
+Q.all(deferreds).then(function() {
+    process.on('exit', function onExit() {
+        reporters.forEach(function(reporter) {
+            fs.statSync("/tmp/spec."+reporter+".out").should.be.ok;            
+        });
+    });
+});
+    

--- a/verify.js
+++ b/verify.js
@@ -8,12 +8,12 @@ var reporters=[
     "dot", "doc", "spec", "json", "progress",
     "list", "tap", "landing", "xunit", "min",
     "json-stream", "markdown", "nyan"
-], deferreds=[];
+], deferreds=[], now=new Date();
 
 reporters.forEach(function(r) {
     var reporter=r, reporterOptions={}, deferred;
     reporterOptions[reporter]={ 
-        stdout:"/tmp/spec."+reporter+".out"
+        stdout:"/tmp/mocha-multi."+reporter+"."+now
     };
     deferred=Q.defer();
     deferreds.push( deferred.promise );
@@ -30,7 +30,7 @@ reporters.forEach(function(r) {
 Q.all(deferreds).then(function() {
     process.on('exit', function onExit() {
         reporters.forEach(function(reporter) {
-            fs.statSync("/tmp/spec."+reporter+".out").should.be.ok;            
+            fs.statSync("/tmp/mocha-multi."+reporter+"."+now).should.be.ok;            
         });
     });
 });


### PR DESCRIPTION
This includes tests in verify.js that programmatically sets the output for each reporter and verifies that the file is created
```sh
$ node verify.js
$ echo $?
```
There is also an update to README.md describing how to use mocha-multi programmatically with this change