### PR TITLE
Added fix to create non-existing output directories.

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var util = require('util');
 var debug = require('debug')('mocha:multi');
+var path = require('path');
 
 // Let mocha decide about tty early
 require('mocha/lib/reporters/base');
@@ -138,6 +139,12 @@ function resolveStream(destination) {
     return null;
   }
   debug("Resolved stream '%s' into writeable file stream", destination);
+  // Create directory if not existing
+  var destinationDir = path.dirname(destination);
+  if (!fs.existsSync(destinationDir)){
+    fs.mkdirSync(destinationDir);
+  }
+
   // Ensure we can write here
   fs.writeFileSync(destination, '');
   return fs.createWriteStream(destination);


### PR DESCRIPTION
When specifying an output file like 
```javascript
json: {
  stdout: 'build/mochaTestResults.json'
}
```
if the directory `build` does not exist (which is quite likely in my setup due to a previous clean), the execution will fail.

I guess it is quite common to at least try to create missing directories for build artifacts. At least mocha does so.
I just added a check on the directory itself, everything else stays the same.