### PR TITLE
Support `--reporter-options` analogously to the `multi` environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Usage
 Choosing Reporters
 ------------------
 
+For both methods below, the special value of `-` (hyphen) for destination uses normal stdout/stderr.
+
+### With the `multi` Environment Variable
+
 Set an environment variable called `multi` to specify the desired reporters.
 Reporters are listed as whitespace separated type=destination pairs.
 
@@ -22,7 +26,13 @@ Reporters are listed as whitespace separated type=destination pairs.
 multi='dot=- xunit=file.xml doc=docs.html' mocha -R mocha-multi
 ```
 
-The special value of `-` (hyphen) for destination uses normal stdout/stderr.
+### With `--reporter-options`
+
+Pass `--reporter-options` with comma-separated type=destination pairs.
+
+```bash
+mocha -R mocha-multi --reporter-options dot=-,xunit=file.xml,doc=docs.html
+```
 
 Using mocha-multi programmatically
 ----------------------------------
@@ -32,8 +42,8 @@ Specify the desired reporters (and their options) by passing reporterOptions to 
 for example: this is the equivalent of multi='spec=- Progress=/tmp/mocha-multi.Progress.out', with the addition of passing the verbose:true option to the Progress reporter
 ```sh
 var reporterOptions={
-	Progress:{ 
-		stdout:"/tmp/mocha-multi.Progress.out",
+	Progress: {
+		stdout: "/tmp/mocha-multi.Progress.out",
 		options: {
 			verbose: true
 		}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ For both methods below, the special value of `-` (hyphen) for destination uses n
 
 ### With the `multi` Environment Variable
 
-Set an environment variable called `multi` to specify the desired reporters.
-Reporters are listed as whitespace separated type=destination pairs.
+Set the environment variable `multi` to whitespace-separated type=destination pairs.
 
 ```bash
 multi='dot=- xunit=file.xml doc=docs.html' mocha -R mocha-multi
@@ -37,13 +36,14 @@ mocha -R mocha-multi --reporter-options dot=-,xunit=file.xml,doc=docs.html
 Using mocha-multi programmatically
 ----------------------------------
 
-Specify the desired reporters (and their options) by passing reporterOptions to the Mocha contructor
+You may specify the desired reporters (and their options) by passing `reporterOptions` to the Mocha contructor.
 
-for example: this is the equivalent of multi='spec=- Progress=/tmp/mocha-multi.Progress.out', with the addition of passing the verbose:true option to the Progress reporter
+For example: the following config is the equivalent of setting `multi='spec=- Progress=/tmp/mocha-multi.Progress.out'`, with the addition of passing the `verbose: true` option to the Progress reporter.
+
 ```sh
-var reporterOptions={
+var reporterOptions = {
 	Progress: {
-		stdout: "/tmp/mocha-multi.Progress.out",
+		stdout:"/tmp/mocha-multi.Progress.out",
 		options: {
 			verbose: true
 		}
@@ -54,16 +54,17 @@ var reporterOptions={
 };
 
 var mocha = new Mocha({
-    ui: 'bdd',
+    ui: "bdd"
     reporter: "mocha-multi",
-    reporterOptions:reporterOptions
+    reporterOptions: reporterOptions
 });
 mocha.addFile("test/dummy-spec.js");
 mocha.run(function onRun(failures){
     console.log(failures);
 });
 ```
-The options will be passed as the second argument to the reporter constructor
+
+The options will be passed as the second argument to the reporter constructor.
 
 How it works
 ------------

--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ For example: the following config is the equivalent of setting `multi='spec=- Pr
 ```sh
 var reporterOptions = {
 	Progress: {
-		stdout:"/tmp/mocha-multi.Progress.out",
+		stdout: "/tmp/mocha-multi.Progress.out",
 		options: {
 			verbose: true
 		}
 	},
-	spec: {
-		stdout:"-"
-	}
+	spec: "-"
 };
 
 var mocha = new Mocha({

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var util = require('util');
 var debug = require('debug')('mocha:multi');
 var path = require('path');
+var isString = require('is-string');
 
 // Let mocha decide about tty early
 require('mocha/lib/reporters/base');
@@ -20,7 +21,18 @@ function MochaMulti(runner, options) {
     setup = [];
     Object.keys(reporters).forEach(function(reporter) {
       debug("adding reporter %j %j", reporter, reporters[reporter]);
-      setup.push([ reporter, reporters[reporter].stdout, reporters[reporter].options ]);
+
+      var stdout;
+      var options;
+      if (isString(reporters[reporter])) {
+        stdout = reporters[reporter];
+        options = null;
+      } else {
+        stdout = reporters[reporter].stdout;
+        options = reporters[reporter].options;
+      }
+
+      setup.push([ reporter, stdout, options ]);
     });
   } else {
     setup = parseSetup();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "should": "^5.2.0"
   },
   "dependencies": {
-    "debug": "~0.7.4"
+    "debug": "~0.7.4",
+    "is-string": "^1.0.4"
   },
   "peerDependencies": {
     "mocha": ">=2 <3.0.0"

--- a/verify
+++ b/verify
@@ -30,7 +30,8 @@ function compare {
   log "Running comparison for $reporter" info
 
   local builtin_out=$(mktemp /tmp/mocha-multi.XXXXXXXXX)
-  local multi_out=$(mktemp /tmp/mocha-multi.XXXXXXXXX)
+  local multi_env_out=$(mktemp /tmp/mocha-multi.XXXXXXXXX)
+  local multi_arg_out=$(mktemp /tmp/mocha-multi.XXXXXXXXX)
 
   local builtin_cmd="mocha -R $reporter &> $builtin_out"
   log "Running formatter normally: $builtin_cmd"
@@ -38,24 +39,35 @@ function compare {
   normalise_timers $builtin_out
 
   # pipe through cat to ensure istty = false
-  local multi_cmd="multi='$reporter=$multi_out' mocha -R $mocha_multi | cat"
-  log "Running formatter via mocha-multi: $multi_cmd"
-  eval $multi_cmd
-  normalise_timers $multi_out
+  local multi_cmd_env="multi='$reporter=$multi_env_out' mocha -R $mocha_multi | cat"
+  log "Running formatter via mocha-multi using environment variable: $multi_cmd_env"
+  eval $multi_cmd_env
+  normalise_timers $multi_env_out
+
+  local multi_arg_env="mocha -R $mocha_multi --reporter-options '$reporter=$multi_arg_out' | cat"
+  log "Running formatter via mocha-multi using --reporter-options: $multi_arg_env"
+  eval $multi_arg_env
+  normalise_timers $multi_arg_out
 
   log "Comparing output"
-  local diff_cmd="diff -U1 -Lbuiltin -Lmulti $builtin_out $multi_out"
-  log "Running $diff_cmd"
-  local difference=$($diff_cmd)
 
-  rm "$builtin_out" "$multi_out"
+  local diff_cmd_env="diff -U1 -Lbuiltin -Lmulti $builtin_out $multi_env_out"
+  log "Running $diff_cmd_env"
+  local difference_env=$($diff_cmd_env)
 
-  if [ "$difference" = "" ]; then
+  local diff_cmd_arg="diff -U1 -Lbuiltin -Lmulti $builtin_out $multi_arg_out"
+  log "Running $diff_cmd_arg"
+  local difference_arg=$($diff_cmd_arg)
+
+  rm "$builtin_out" "$multi_env_out" "$multi_arg_out"
+
+  if [ "$difference_env" = "" -a "$difference_arg" = "" ]; then
     log 'Output matches, hooray!' pass
     return 0
   else
     log "Output does not match" fail
-    log "Difference\n${normal}$difference"
+    log "Difference (env)\n${normal}$difference_env"
+    log "Difference (arg)\n${normal}$difference_arg"
     return 1
   fi
 }

--- a/verify.js
+++ b/verify.js
@@ -9,9 +9,7 @@ var reporters = [
     "dot", "doc", "spec", "json", "progress",
     "list", "tap", "landing", "xunit", "min",
     "json-stream", "markdown", "nyan"
-];
-
-var now = new Date();
+], now = new Date();
 
 var reportersWithOptions = []
     .concat(reporters.map(function (reporter) {


### PR DESCRIPTION
If `reporterOptions` is a string, assume it's just the stdout specification passed on the command line, just like we do with `process.env.multi`.

Fixes #10.