### PR TITLE
Updating mocha dependency to include version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "chalk": "^1.0.0",
-    "mocha": ">=2 <3.0.0",
+    "mocha": ">=2 <4.0.0",
     "q": "^1.2.0",
     "should": "^5.2.0"
   },
@@ -32,6 +32,6 @@
     "mkdirp": "^0.5.1"
   },
   "peerDependencies": {
-    "mocha": ">=2 <3.0.0"
+    "mocha": ">=2 <4.0.0"
   }
 }


### PR DESCRIPTION
The mocha dev dependency and peer dependency is updated to also
include version 3 since ocha-multi is working with Mocha version
3.0.0.