### PR TITLE
[#23] Invoke done(fn) on reporters that have it on completion

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -8,8 +8,6 @@ var mkdirp = require('mkdirp');
 // Let mocha decide about tty early
 require('mocha/lib/reporters/base');
 
-var Base = require('mocha').reporters.Base;
-
 module.exports = MochaMulti
 
 // Make sure we don't lose these!
@@ -52,8 +50,6 @@ function MochaMulti(runner, options) {
     awaitStreamsOnExit(streams);
   }
 }
-
-util.inherits(MochaMulti, Base);
 
 /**
  * Override done to allow done processing for any reporters that have a done method.


### PR DESCRIPTION
This appears to fix #23 for me.   Verified with:

```bash
DEBUG="mocha:multi" mocha -R mocha-multi --reporter-options dot=-,xunit=file.xml,doc=docs.html
```

Also worked for me with [`mocha-appveyor-reporter`](https://github.com/tolbertam/mocha-appveyor-reporter/) which makes sure all tests have been uploaded to appveyor as part of completion via `done`.  (Example job: https://ci.appveyor.com/project/tolbertam/nodejs-driver/build/job/ujufnnly3tek0y7g)