### PR TITLE
Fix fn is not a function in case, when reports haven't a done method

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -74,7 +74,6 @@ MochaMulti.prototype.done = function (failures, fn) {
     });
   } else {
     debug('No reporters have done method, completing.');
-    fn(failures);
   }
 };
 


### PR DESCRIPTION
Fix fn is not a function in case, when reports haven't a done method

    fn(failures);
    ^

TypeError: fn is not a function