### PR TITLE
Pass options to reporters more correct

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var util = require('util');
+var assign = require('object-assign');
 var debug = require('debug')('mocha:multi');
 var path = require('path');
 var isString = require('is-string');
@@ -16,6 +17,7 @@ var stderr = process.stderr;
 
 function MochaMulti(runner, options) {
   var setup;
+  this.options = options;
   // keep track of reporters that have a done method.
   this.reportersWithDone = [];
   var reporters = (options && options.reporterOptions);
@@ -124,7 +126,9 @@ function initReportersAndStreams(runner, setup, multi) {
 
     withReplacedStdout(stream, function() {
       var Reporter = resolveReporter(reporter);
-      var r = new Reporter(shim, options || {});
+      var r = new Reporter(shim, assign({}, multi.options, {
+        reporterOptions: options || {}
+      }));
       // If the reporter possess a done() method register it so we can
       // wait for it to complete when done.
       if(r && r.done) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "debug": "~0.7.4",
     "is-string": "^1.0.4",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "object-assign": "^4.1.1"
   },
   "peerDependencies": {
     "mocha": ">=2 <4.0.0"


### PR DESCRIPTION
Currently it is not possible to use Mocha-multi with `xunit` reporter and any others that require some options.

Here is a little example:
```js
var Mocha = require('mocha');
var mocha = new Mocha({
    reporter: require('./'),
    reporterOptions: {
        xunit: {
            stdout: '-',
            options: {
                output: 'xunit-report.xml'
            }
        },
        spec: '-'
    }
});

mocha.addFile('test/dummy-spec.js');
mocha.loadFiles();
mocha.run(function() {
    console.log('ok');
})
```

I expect this to work, but `xunit` reporter doesn't receive proper configuration and doesn't work.
As you can see from [the source code of xunit-reporter](https://github.com/mochajs/mocha/blob/master/lib/reporters/xunit.js#L46), it expects configuration object with `repoterOptions` key instead of options directly.

This fix makes it working, and code example above produces output as expected.