### PR TITLE
Mocha 6 'stats' support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,9 @@
         "no-process-exit": 0,
         "no-underscore-dangle": 0,
         "no-unused-expressions": 0,
-        "node/no-unpublished-require": 0
+        "node/no-unpublished-require": 0,
+        "operator-linebreak": [ "error", "after" ],
+        "strict": 0
     },
     "overrides": [
         {

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -47,7 +47,7 @@ const msgs = {
   invalid_reporter: "Unable to find '%s' reporter",
   invalid_setup: "Invalid setup for reporter '%s' (%s)",
   invalid_outfile: "Invalid stdout filename for reporter '%s' (%s)",
-  bad_file: "Missing or malformed options file '%s' -- %s",
+  bad_file: "Missing or malformed options file '%s' -- Error: %s",
 };
 function bombOut(id, ...args) {
   const newArgs = [`ERROR: ${msgs[id]}`, ...args];
@@ -71,7 +71,7 @@ function convertSetup(reporters) {
       try {
         setup = setup.concat(convertSetup(JSON.parse(fs.readFileSync(reporters[reporter]))));
       } catch (e) {
-        bombOut('bad_file', reporters[reporter], e);
+        bombOut('bad_file', reporters[reporter], e.message);
       }
     } else {
       const r = reporters[reporter];

--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -181,6 +181,7 @@ function createRunnerShim(runner, stream) {
   addDelegate('grepTotal');
   addDelegate('suite');
   addDelegate('total');
+  addDelegate('stats');
 
   const delegatedEvents = {};
 

--- a/package.json
+++ b/package.json
@@ -24,26 +24,26 @@
   },
   "homepage": "https://github.com/glenjamin/mocha-multi",
   "devDependencies": {
-    "async": "^2.5.0",
-    "chalk": "^2.1.0",
-    "eslint": "^4.8.0",
-    "eslint-config-airbnb-base": "^12.0.1",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-node": "^5.2.0",
-    "mocha": "^4.0.0",
-    "npm-run-all": "^4.1.1",
-    "q": "^1.2.0",
-    "should": "^13.1.0"
+    "async": "^3.0.1",
+    "chalk": "^2.4.2",
+    "eslint": "^5.16.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-node": "^9.1.0",
+    "mocha": "^6.1.4",
+    "npm-run-all": "^4.1.5",
+    "q": "^1.5.1",
+    "should": "^13.2.3"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "is-string": "^1.0.4",
     "lodash.once": "^4.1.1",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "mocha": ">=2.2.0 <6.0.0"
+    "mocha": "^6.1.4"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/verify
+++ b/verify
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mocha_multi="../../../mocha-multi.js"
+mocha_multi="./mocha-multi.js"
 normal="\033[0m"
 
 function log {


### PR DESCRIPTION
Hello,

I had an issue running mocha-multi with mocha 6.1.4, it seems that latest mocha versions adds a 'stats' property on runner objects.

The command I was running:
```bash
multi="mocha-notifier-reporter=- spec=-" mocha -R mocha-multi
```

Thrown error:
```
.../node_modules/mocha-notifier-reporter/index.js:19
	stats.total = runner.total;
	            ^

TypeError: Cannot set property 'total' of undefined
    at notify (.../node_modules/mocha-notifier-reporter/index.js:19:14)
    at NotifyReporter.<anonymous> (.../node_modules/mocha-notifier-reporter/index.js:44:3)
    at EventEmitter.emit (events.js:182:13)
    at withReplacedStdout (.../node_modules/mocha-multi/mocha-multi.js:197:14)
    at withReplacedStdout (.../node_modules/mocha-multi/mocha-multi.js:146:12)
    at Runner.runner.on.eventArgs (.../node_modules/mocha-multi/mocha-multi.js:196:7)
    at Runner.emit (events.js:187:15)
    at .../node_modules/mocha/lib/runner.js:903:12
    at done (.../node_modules/mocha/lib/runner.js:761:7)
    at next (.../node_modules/mocha/lib/runner.js:728:16)
    at done (.../node_modules/mocha/lib/runner.js:761:7)
    at next (.../node_modules/mocha/lib/runner.js:732:14)
    at Runner.hookErr (.../node_modules/mocha/lib/runner.js:575:7)
    at Runner.uncaught (.../node_modules/mocha/lib/runner.js:857:19)
    at process.uncaught (.../node_modules/mocha/lib/runner.js:887:10)
    at process.emit (events.js:182:13)
    at process._fatalException (internal/bootstrap/node.js:491:27)
```

This patch solves the issue, ran `npm run test` on it
