### PR TITLE
Fix issues with custom reporter loading

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -135,6 +135,7 @@ function resolveReporter(name) {
   const reporter = (
     safeRequire(`mocha/lib/reporters/${name}`) ||
     safeRequire(name) ||
+    safeRequire(path.resolve(process.cwd(), name)) ||
     bombOut('invalid_reporter', name)
   );
   debug("Resolved reporter '%s' into '%s'", name, util.inspect(reporter));


### PR DESCRIPTION
custom reporters defined as a `relative/path/to/reporter.js` are not working right now. This PR fixes it.