### PR TITLE
Allow mocha-multi to be configured with an object via a mocharc file.

### DIFF
--- a/mocha-multi.js
+++ b/mocha-multi.js
@@ -293,6 +293,14 @@ function mochaMulti(runner, options) {
 
 class MochaMulti {
   constructor(runner, options) {
+    debugger;
+    if (options.mochaMultiOptions) {
+      let reporterOptions = options.mochaMultiOptions;
+      if (typeof reporterOptions === 'string') {
+        reporterOptions = JSON.parse(reporterOptions);
+      }
+      Object.assign(options, { reporterOptions });
+    }
     Object.assign(this, mochaMulti(runner, options));
   }
 }


### PR DESCRIPTION
Our configuration of the reporter requires passing an object, but
doing so via a mocharc file does not work because the option parser
only supports key=value pairs and any supplied object is trampled
before the reporter can is instantiated.

Solve this by allowing mocha-multi options to be specified using a
separate "mochaMultiOptions" key that can contain an object encoded
as JSON - this will be left alone by the mocha options parser and
thus the reporter is able to get hold of the necessary options.