### PR TITLE
Fix semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "mocha": "2.2.0-7.0.0 || ^9.0.0"
+    "mocha": "2.2.0 - 7.0.0 || ^9.0.0"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
It looks like the [syntax for the range](https://docs.npmjs.com/cli/v6/using-npm/semver#hyphen-ranges-xyz---abc) in the peer dependencies is incorrect. This should fix #82 